### PR TITLE
Provision / Fix postgres credentials requirement / Fixes #8

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,6 +26,7 @@ Vagrant.configure(2) do |config|
     config.ssh.forward_agent = true
 
     # Enable provisioning with a shell script.
+    config.vm.provision :shell, :path => "vagrant/postgres.sh"
     config.vm.provision :shell, :path => "vagrant/provision.sh", :args => [PROJECT_NAME, "requirements/dev.txt"]
 
     # If a 'Vagrantfile.local' file exists, import any configuration settings

--- a/vagrant/postgres.sh
+++ b/vagrant/postgres.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+
+# Let us connect to the database from the localhost without credentials
+su - vagrant -c "echo -n 'Changing postgres authorisation method ... ' && \
+                 sudo sed -i 's/local\s\{1,\}all\s\{1,\}postgres\s\{1,\}peer/local all postgres trust/g' \
+                             /etc/postgresql/9.3/main/pg_hba.conf && \
+                 echo done! && \
+                 sudo service postgresql restart"


### PR DESCRIPTION
Motivated by https://github.com/springload/wagtailsites/pull/10

We can make another provision script, that will only confgure postgresql. When Torchbox guys fix the issue, that script can be deleted without any concerns about original provision.sh.